### PR TITLE
(MAINT) Style figure for left-float

### DIFF
--- a/blog/assets/scss/custom.scss
+++ b/blog/assets/scss/custom.scss
@@ -1,3 +1,9 @@
 .float-left {
     float: left;
 }
+
+figure.float-left {
+    max-width: fit-content;
+    margin-right: var(--card-padding);
+    margin-left: var(--card-padding);
+}

--- a/blog/content/post/2018/t-sql-tuesday-99/index.md
+++ b/blog/content/post/2018/t-sql-tuesday-99/index.md
@@ -11,11 +11,19 @@ tags:
 
 <!--
 TODO:
- - T-SQL image float left
  - photo gallery
 -->
 
-[![MJTuesday](tsqltues-300x300.png)](https://sqlblog.org/2018/02/06/t-sql-tuesday-99)First off, welcome to my first T-SQL Tuesday which seems like the perfect first blog post to introduce myself and my non-SQL Server life.  Starting this blog and becoming more involved with the SQL Server community (read speaking) is my goal for 2018 so here goes nothing. Thanks to [Aaron Bertrand](http://twitter.com/AaronBertrand) for hosting and picking a great topic.
+{{<
+  figure src="tsqltues-300x300.png"
+         link="https://sqlblog.org/2018/02/06/t-sql-tuesday-99"
+         title="MJTuesday"
+         class="float-left"
+         width="300px"
+         height="300px"
+>}}
+
+First off, welcome to my first T-SQL Tuesday which seems like the perfect first blog post to introduce myself and my non-SQL Server life.  Starting this blog and becoming more involved with the SQL Server community (read speaking) is my goal for 2018 so here goes nothing. Thanks to [Aaron Bertrand](http://twitter.com/AaronBertrand) for hosting and picking a great topic.
 
 I was born in Oxford, England before my family moved to the small market town of [Chippenham, Wiltshire](https://en.wikipedia.org/wiki/chippenham) where I was raised.  Leading to my main passion being proper football. We can argue about why this is the proper football in a later post perhaps (hint: you use your feet to kick a ball, no hands or egg-shaped objects here).
 


### PR DESCRIPTION
This commit adds styling to enable floating figures left in markdown content.

It sets the max-width of the figure to its content size, overwriting the default value of 100%, and inverts the card padding from negative back to positive, creating some breathing room for the figure.